### PR TITLE
Despecialised waits into generic system

### DIFF
--- a/bay/constants.py
+++ b/bay/constants.py
@@ -2,5 +2,6 @@ class PluginHook:
     PRE_BUILD = "pre-build"
     POST_BUILD = "post-build"
     PRE_START = "pre-start"
+    POST_START = "post-start"
 
-    valid_hooks = frozenset([PRE_BUILD, POST_BUILD, PRE_START])
+    valid_hooks = frozenset([PRE_BUILD, POST_BUILD, PRE_START, POST_START])

--- a/bay/plugins/base.py
+++ b/bay/plugins/base.py
@@ -43,5 +43,8 @@ class BasePlugin(object, metaclass=PluginMetaclass):
     def add_hook(self, hook_type, func):
         self.app.add_hook(hook_type, func)
 
-    def add_wait(self, name, klass):
-        self.app.add_wait(name, klass)
+    def add_catalog_type(self, name):
+        self.app.add_catalog_type(name)
+
+    def add_catalog_item(self, type_name, name, value):
+        self.app.add_catalog_item(type_name, name, value)


### PR DESCRIPTION
Rather than have waits be core, it's moved to a plugin and then the old
app registration for waits is made more generic into a "catalog" system
that any plugin can use. A post-start hook is added too to power the
waits.