### PR TITLE
Make bay only print to console 10 times a second

### DIFF
--- a/bay/cli/__init__.py
+++ b/bay/cli/__init__.py
@@ -38,6 +38,7 @@ class App(object):
         self.hosts = HostManager.from_config(self.config)
         self.containers = ContainerGraph(self.config["bay"]["home"])
         self.root_task = RootTask()
+        self.root_task.start_output_thread()
 
     def load_plugins(self):
         """


### PR DESCRIPTION
Uses a thread to limit the amount of output so the console won't flicker
or get too slow if there's hundreds of updates a second (e.g. during
build, pull)