### PR TITLE
Add ability to say what tags to use for container images.

### DIFF
--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -131,12 +131,13 @@ class Container:
         self.build_checks = config_data.get("build_checks", [])
         self._devmodes = config_data.get("devmodes", {})
         self.foreground = config_data.get("foreground", False)
+        self.image_tag = config_data.get("image_tag", "local")
         self.buildargs = {}
         # Store all extra data so plugins can get to it
         self.extra_data = {
             key: value
             for key, value in config_data.items()
-            if key not in ["ports", "build_checks", "devmodes", "foreground", "links", "waits", "volumes"]
+            if key not in ["ports", "build_checks", "devmodes", "foreground", "links", "waits", "volumes", "image_tag"]
         }
 
     def get_parent_value(self, name, default):

--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -72,7 +72,7 @@ class ContainerFormation:
             if dependency in direct_dependencies:
                 links[dependency.name] = instance
         # Look up the image hash to use in the repo
-        image_id = host.images.image_version(container.image_name, "latest")
+        image_id = host.images.image_version(container.image_name, container.image_tag)
         # Make the instance
         instance = ContainerInstance(
             name="{}.{}.1".format(self.graph.prefix, container.name),

--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -107,6 +107,9 @@ class Profile:
                     int(a): int(b)
                     for a, b in details["ports"].items()
                 }
+            # Apply any image tag override
+            if "image_tag" in details:
+                container.image_tag = details['image_tag']
 
     def calculate_links(self, container):
         """

--- a/bay/docker/images.py
+++ b/bay/docker/images.py
@@ -54,7 +54,14 @@ class ImageRepository:
         # The string "local" has a special meaning which means the most recent
         # local image of that name, so we skip the remote call/check.
         if image_tag == "local":
-            return None
+            if fail_silently:
+                return None
+            else:
+                raise ImagePullFailure(
+                    "Cannot pull a local image",
+                    remote_name=None,
+                    image_tag=image_tag
+                )
 
         remote_name = "{registry_url}/{image_name}".format(
             registry_url=registry_url,

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -67,7 +67,7 @@ def build(app, containers, host, cache, recursive, verbose):
         try:
             host.images.pull_image_version(
                 container.image_name,
-                "latest",
+                container.image_tag,
                 parent_task=task,
                 fail_silently=False,
             )
@@ -99,7 +99,7 @@ def build(app, containers, host, cache, recursive, verbose):
                     if ancestor not in pulled_containers:
                         host.images.pull_image_version(
                             ancestor.image_name,
-                            "latest",
+                            ancestor.image_tag,
                             parent_task=task,
                             fail_silently=False,
                         )


### PR DESCRIPTION
Defaults to "local", which acts as the "unmaintained" flag to always
build locally and never try pulling. Can be overridden either by a
container or by a profile.