### PR TITLE
Fix tug mount and runtime resolution issues

### DIFF
--- a/bay/cli/__init__.py
+++ b/bay/cli/__init__.py
@@ -89,19 +89,22 @@ class App(object):
         )
 
         if os.path.exists(user_profile_path):
-            user_profile = Profile(user_profile_path)
+            self.user_profile = Profile(user_profile_path)
         else:
-            user_profile = NullProfile()
+            self.user_profile = NullProfile()
 
-        if user_profile.parent_profile:
-            parent_profile = Profile(os.path.join(
-                self.config["bay"]["home"],
-                "profiles",
-                "{}.yaml".format(user_profile.parent_profile)
-            ))
-            parent_profile.apply(self.containers)
+        if self.user_profile.parent_profile:
+            self.parent_profile = Profile(
+                os.path.join(
+                    self.config["bay"]["home"],
+                    "profiles",
+                    "{}.yaml".format(self.user_profile.parent_profile)
+                ),
+                default_boot_compatability=True,
+            )
+            self.parent_profile.apply(self.containers)
 
-        user_profile.apply(self.containers)
+        self.user_profile.apply(self.containers)
 
     def add_hook(self, hook_type, receiver):
         """
@@ -150,6 +153,14 @@ class App(object):
         Given a plugin's class, returns the instance of it we have loaded.
         """
         return self.plugins[klass]
+
+    def invoke(self, command_name, **kwargs):
+        """
+        Runs a [sub]command by name, passing context automatically.
+        """
+        context = click.get_current_context()
+        command = cli.get_command(context, command_name)
+        context.invoke(command, **kwargs)
 
 
 class AppGroup(SpellcheckableAliasableGroup):

--- a/bay/cli/tasks.py
+++ b/bay/cli/tasks.py
@@ -26,8 +26,10 @@ class Task:
     FLAVOR_BAD = "bad"
     FLAVOR_WARNING = "warning"
 
-    def __init__(self, name, parent=None):
+    def __init__(self, name, parent=None, hide_if_empty=False):
         self.name = name
+        # If this task only displays if it has children
+        self.hide_if_empty = False
         # Any parent tasks to trigger updates in
         self.parent = parent
         with console_lock:
@@ -105,6 +107,8 @@ class Task:
         """
         Returns the number of console lines this task will need to print itself.
         """
+        if self.hide_if_empty and not self.subtasks:
+            return 0
         return 1 + sum(subtask.lines() for subtask in self.subtasks) + len(self.extra_info)
 
     def make_progress_bar(self, count, total, width=30):
@@ -127,6 +131,8 @@ class Task:
         Assumes that the screen is already cleared and the cursor is in the right
         place.
         """
+        if self.hide_if_empty and not self.subtasks:
+            return
         # Get terminal width
         terminal_width = shutil.get_terminal_size((80, 20)).columns
         # Work out progress text

--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -1,4 +1,5 @@
 import attr
+import warnings
 
 from ..exceptions import BadConfigError
 from ..utils.sorting import dependency_sort
@@ -21,10 +22,10 @@ class ContainerFormation:
     to the host; higher-level management of a set of different hosts is done
     elsewhere.
     """
-    graph = attr.ib()
+    graph = attr.ib(repr=False)
     network = attr.ib(default=None)  # a string network name, defaults to graph.prefix
-    _instances = attr.ib(default=attr.Factory(list))
-    container_instances = attr.ib(default=attr.Factory(dict), init=False)
+    _instances = attr.ib(default=attr.Factory(list), repr=False)
+    container_instances = attr.ib(default=attr.Factory(dict), init=False, repr=False)
 
     def __attrs_post_init__(self):
         if self.network is None:
@@ -32,6 +33,10 @@ class ContainerFormation:
 
         for instance in self._instances:
             self.add_instance(instance)
+
+    def validate(self):
+        for instance in self:
+            instance.validate()
 
     def add_instance(self, instance):
         """
@@ -45,7 +50,15 @@ class ContainerFormation:
         """
         Removes an instance from the formation
         """
+        # Make sure the instance being removed is part of us
         assert instance.formation is self
+        # Resolve the dependent containers so they can all be removed
+        dependent_descendency = set(dependency_sort([instance.container], self.graph.dependents)[:-1])
+        for other_instance in list(self):
+            if other_instance.container in dependent_descendency:
+                other_instance.formation = None
+                del self.container_instances[other_instance.name]
+        # Remove the requested container
         del self.container_instances[instance.name]
         instance.formation = None
 
@@ -94,6 +107,12 @@ class ContainerFormation:
             new.add_instance(instance.clone())
         return new
 
+    def has_container(self, container):
+        """
+        Returns True if the formation has an instance running the given container.
+        """
+        return any(instance.container == container for instance in self)
+
     def __getitem__(self, key):
         return self.container_instances[key]
 
@@ -124,17 +143,16 @@ class ContainerInstance:
     name = attr.ib()
     container = attr.ib()
     image_id = attr.ib()
-    links = attr.ib(default=attr.Factory(dict))
-    devmodes = attr.ib(default=attr.Factory(set))
-    ports = attr.ib(default=attr.Factory(dict))
-    environment = attr.ib(default=attr.Factory(dict))
-    command = attr.ib(default=None)
-    foreground = attr.ib(default=None)
-    formation = attr.ib(default=None, init=False)
+    links = attr.ib(default=attr.Factory(dict), repr=False)
+    devmodes = attr.ib(default=attr.Factory(set), repr=False)
+    ports = attr.ib(default=attr.Factory(dict), repr=False)
+    environment = attr.ib(default=attr.Factory(dict), repr=False)
+    command = attr.ib(default=None, repr=False)
+    foreground = attr.ib(default=None, repr=False)
+    formation = attr.ib(default=None, init=False, repr=False)
 
     def __attrs_post_init__(self):
         self.ports.update(dict(self.container.ports.items()))
-        self.validate()
 
     def validate(self):
         """
@@ -142,6 +160,8 @@ class ContainerInstance:
         """
         # Verify all link targets are possible
         for alias, target in self.links.items():
+            if isinstance(target, str):
+                raise ValueError("Link target {} is still a string!".format(target))
             if target.container not in self.container.graph.dependencies(self.container):
                 raise BadConfigError("It is not possible to link %s to %s as %s" % (target, self.container, alias))
         # Verify devmodes exist
@@ -182,6 +202,20 @@ class ContainerInstance:
             other.foreground or
             self.foreground
         )
+
+    def resolve_links(self):
+        """
+        Resolves any links that are still names to instances from the formation
+        """
+        for alias, target in list(self.links.items()):
+            if isinstance(target, str):
+                try:
+                    target = self.formation[target]
+                except KeyError:
+                    del self.links[alias]
+                    warnings.warn("Could not resolve link {} to an instance for {}".format(target, self.name))
+                else:
+                    self.links[alias] = target
 
     def __eq__(self, other):
         return self.name == other.name

--- a/bay/containers/graph.py
+++ b/bay/containers/graph.py
@@ -18,10 +18,10 @@ class ContainerGraph:
     containers to start by default.
     """
     path = attr.ib(convert=os.path.abspath)
-    containers = attr.ib(default=attr.Factory(dict), init=False)
-    _dependencies = attr.ib(default=attr.Factory(dict))
-    _build_dependencies = attr.ib(default=attr.Factory(dict), init=False)
-    _options = attr.ib(default=attr.Factory(dict), init=False)
+    containers = attr.ib(default=attr.Factory(dict), init=False, repr=False)
+    _dependencies = attr.ib(default=attr.Factory(dict), repr=False)
+    _build_dependencies = attr.ib(default=attr.Factory(dict), init=False, repr=False)
+    _options = attr.ib(default=attr.Factory(dict), init=False, repr=False)
     config_path = attr.ib(init=False)
 
     def __attrs_post_init__(self):

--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -16,6 +16,7 @@ class Profile:
     """
     file_path = attr.ib(default=None)
     load_immediately = attr.ib(default=True)
+    default_boot_compatability = attr.ib(default=False)
     parent_profile = attr.ib(default=None, init=False)
     description = attr.ib(default=None, init=False)
     version = attr.ib(default=None, init=False)
@@ -98,7 +99,12 @@ class Profile:
                     for link in self.calculate_links(container)],
                 )
             # Set default boot mode
-            self.graph.set_option(container, "default_boot", True)
+            if details.get('default_boot'):
+                self.graph.set_option(container, "default_boot", True)
+            # TODO: Remove this temporary fix that allows parent profiles default boot based on just
+            # having the container in the profile.
+            if self.default_boot_compatability:
+                self.graph.set_option(container, "default_boot", True)
             # Set devmodes
             self.graph.set_option(container, "devmodes", details["devmodes"])
             # Set ports to apply

--- a/bay/docker/introspect.py
+++ b/bay/docker/introspect.py
@@ -56,6 +56,8 @@ class FormationIntrospector:
         # Find the container name in the graph
         try:
             labels = container_details['Config']['Labels']
+            # Use the bay-specific (not eventbrite-specific, just named uniquely as per the docker label spec) label
+            # to work out what container name this was.
             container = self.graph[labels['com.eventbrite.bay.container']]
         except KeyError:
             raise DockerRuntimeError(

--- a/bay/plugins/container.py
+++ b/bay/plugins/container.py
@@ -61,3 +61,9 @@ def container(app, container=None):
         click.echo(CYAN("Bind-mounted volumes:"))
         for mount_point, source in container.bound_volumes.items():
             click.echo("  {}: {}".format(mount_point, source))
+        # Devmodes
+        click.echo(CYAN("Mounts (devmodes):"))
+        for name, mounts in container.devmodes.items():
+            click.echo("  {}:".format(name))
+            for mount_point, source in mounts.items():
+                click.echo("    {}: {}".format(mount_point, source))

--- a/bay/plugins/run.py
+++ b/bay/plugins/run.py
@@ -31,9 +31,9 @@ class RunPlugin(BasePlugin):
 @click.command()
 @click.argument("containers", type=ContainerType(), nargs=-1)
 @click.option("--host", "-h", type=HostType(), default="default")
-@click.option("--follow/--nofollow", "-f", default=False)
+@click.option("--tail/--notail", "-t", default=False)
 @click.pass_obj
-def run(app, containers, host, follow):
+def run(app, containers, host, tail):
     """
     Runs containers by name, including any dependencies needed
     """
@@ -51,7 +51,7 @@ def run(app, containers, host, follow):
     task = Task("Starting containers", parent=app.root_task)
     run_formation(app, host, formation, task)
     # If they asked to tail, then run tail
-    if follow:
+    if tail:
         if len(containers) != 1:
             click.echo(RED("You cannot tail more than one container!"))
             sys.exit(1)


### PR DESCRIPTION
* Removes custom restart-containers code from tug mount and uses tug up instead
* Fixes tug up/stop to stop dependent containers first
* Unifies the threading code for runner into a single function
* Adds a new way of calling other commands that removes the need to pass the context along
* Make the reprs of some of the bigger objects more readable
* Moved devmount git resolution code alongside the volume git resolution code in Container
* Turned off default-boot for user profiles' container names, with deprecation path for it totally
* Made the introspector populate all parts of an instance