### PR TITLE
Applying multiple profiles to the same graph does not overwrite ports

### DIFF
--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -114,10 +114,11 @@ class Profile:
             self.graph.set_option(container, "devmodes", details["devmodes"])
             # Set ports to apply
             if "ports" in details:
-                container.ports = {
-                    int(a): int(b)
-                    for a, b in details["ports"].items()
-                }
+                for a, b in details["ports"].items():
+                    try:
+                        container.ports[int(a)] = int(b)
+                    except TypeError:
+                        raise BadConfigError('Profile contains invalid ports for {}: {}'.format(a, b))
             # Apply any image tag override
             if "image_tag" in details:
                 container.image_tag = details['image_tag']


### PR DESCRIPTION
Previously, when bay would apply the user profile after applying the parent profile, it would overwrite the port mapping from the parent profile with the port mapping in the user profile.

The fix is to merge the second profile ports onto the existing one, so only keys that are specified in the second profile are overwritten.