### PR TITLE
Make `bay build profile` build everything specified in a profile file

### DIFF
--- a/bay/containers/graph.py
+++ b/bay/containers/graph.py
@@ -103,7 +103,7 @@ class ContainerGraph:
         Sets the option named `option` on the container to the given value.
         Also does some basic checks of what valid options are.
         """
-        if option == "default_boot":
+        if option in ("default_boot", "in_profile"):
             value = bool(value)
         elif option == "devmodes":
             if not isinstance(value, set):

--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -103,6 +103,8 @@ class Profile:
                     [self.graph[link]
                     for link in self.calculate_links(container)],
                 )
+            # Set flag saying it's specified in a profile (for bay build profile)
+            self.graph.set_option(container, "in_profile", True)
             # Set default boot mode
             if details.get('default_boot'):
                 self.graph.set_option(container, "default_boot", True)

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -52,7 +52,7 @@ def build(app, containers, host, cache, recursive, verbose):
     for container in containers:
         if container is ContainerType.Profile:
             for con in app.containers:
-                if app.containers.options(con).get('default_boot'):
+                if app.containers.options(con).get('in_profile'):
                     containers_to_pull.append(con)
         else:
             containers_to_build.append(container)


### PR DESCRIPTION
It was only building default-boot ones before, which meant it didn't build foreground containers.