### PR TITLE
Add optional memory output to the "bay ps" command, and a test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build
 .coverage
 .idea
 .DS_Store
+.cache
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
     - '3.6'
 
 install:
-    - pip install flake8
+    - pip install -U pip setuptools flake8
 
 script:
     - flake8 .
+    - python setup.py test

--- a/bay/plugins/ps.py
+++ b/bay/plugins/ps.py
@@ -5,6 +5,7 @@ from .base import BasePlugin
 from ..cli.argument_types import HostType
 from ..cli.table import Table
 from ..docker.introspect import FormationIntrospector
+from ..utils import humanize
 
 
 @attr.s
@@ -19,22 +20,41 @@ class PsPlugin(BasePlugin):
 
 @click.command()
 @click.option("--host", "-h", type=HostType(), default="default")
+@click.option("--stats/--no-stats", "-s")
 @click.pass_obj
-def ps(app, host):
+def ps(app, host, stats):
     """
     Shows details about all containers currently running
     """
     # Run the introspector to get the details
     formation = FormationIntrospector(host, app.containers).introspect()
     # Print formation details
-    table = Table([("NAME", 30), ("DOCKER NAME", 40), ("PORTS (CONTAINER->HOST)", 30)])
+    if stats:
+        table = Table([
+            ("NAME", 30),
+            ("DOCKER NAME", 40),
+            ("MEMORY", 10),
+            ("PORTS (CONTAINER->HOST)", 30),
+        ])
+    else:
+        table = Table([
+            ("NAME", 30),
+            ("DOCKER NAME", 40),
+            ("PORTS (CONTAINER->HOST)", 30),
+        ])
     table.print_header()
     for instance in sorted(formation, key=lambda i: i.name):
-        table.print_row([
+        row = [
             instance.container.name,
             instance.name,
-            ", ".join(
-                "{}->{}".format(private, public)
-                for private, public in instance.port_mapping.items()
-            ),
-        ])
+        ]
+        if stats:
+            # Get the memory usage from the docker host
+            stats = host.client.stats(instance.name, decode=True, stream=False)
+            row.append(humanize.file_size(stats['memory_stats']['usage']))
+        # Add in port info
+        row.append(", ".join(
+            "{}->{}".format(private, public)
+            for private, public in instance.port_mapping.items()
+        ))
+        table.print_row(row)

--- a/bay/utils/humanize.py
+++ b/bay/utils/humanize.py
@@ -1,0 +1,15 @@
+def file_size(value, fmt="{value:.1f} {suffix}", si=False):
+    """
+    Takes a raw number of bytes and returns a humanized filesize.
+    """
+    if si:
+        base = 1000
+        suffixes = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    else:
+        base = 1024
+        suffixes = ("B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
+    max_suffix_index = len(suffixes) - 1
+    for i, suffix in enumerate(suffixes):
+        unit = base ** (i + 1)
+        if value < unit or i == max_suffix_index:
+            return fmt.format(value=(base * value / unit), suffix=suffix)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ max-line-length = 119
 
 [bdist_wheel]
 python-tag = py33
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
         'spell': ['pylev'],
     },
     test_suite="tests",
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     entry_points='''
         [console_scripts]
         bay = bay.cli:cli

--- a/tests/test_humanize.py
+++ b/tests/test_humanize.py
@@ -1,0 +1,53 @@
+import unittest
+
+from bay.utils.humanize import file_size
+
+
+class FilesizeTests(unittest.TestCase):
+    """
+    Tests the filesize formatter
+    """
+
+    def test_binary_values(self):
+        self.assertEqual(
+            file_size(1),
+            "1.0 B",
+        )
+        self.assertEqual(
+            file_size(1024),
+            "1.0 KiB",
+        )
+        self.assertEqual(
+            file_size(1524),
+            "1.5 KiB",
+        )
+        self.assertEqual(
+            file_size(5500928),
+            "5.2 MiB",
+        )
+        self.assertEqual(
+            file_size(7300613312),
+            "6.8 GiB",
+        )
+
+    def test_decimal_values(self):
+        self.assertEqual(
+            file_size(1, si=True),
+            "1.0 B",
+        )
+        self.assertEqual(
+            file_size(1024, si=True),
+            "1.0 KB",
+        )
+        self.assertEqual(
+            file_size(1524, si=True),
+            "1.5 KB",
+        )
+        self.assertEqual(
+            file_size(5500928, si=True),
+            "5.5 MB",
+        )
+        self.assertEqual(
+            file_size(7300613312, si=True),
+            "7.3 GB",
+        )


### PR DESCRIPTION
It's optional because fetching memory usage takes about 1s per container
for some reason.