### PR TITLE
Rework profiles to inherit and correctly handle links

### DIFF
--- a/bay/containers/graph.py
+++ b/bay/containers/graph.py
@@ -80,7 +80,15 @@ class ContainerGraph:
         # Link by dependency
         for container in containers:
             # Runtime dependencies
-            self.set_dependencies(container, [self.containers[link] for link in container.default_links])
+            self.set_dependencies(
+                container,
+                [
+                    self.containers[link_name]
+                    for link_name, link_details
+                    in container.links.items()
+                    if link_details.get("required")
+                ],
+            )
             # Build dependencies
             if container.build_parent_in_prefix:
                 self.add_build_dependency(container, self.containers[container.build_parent.split("/")[1]])

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -193,6 +193,10 @@ class FormationRunner:
         """
         Creates the Docker container on the host, ready to be started.
         """
+        # Make sure it's not an abstract container being started.
+        if instance.container.abstract and not instance.foreground:
+            raise ValueError("You cannot boot an abstract container.")
+
         # Wait for the global container manipulation lock
         with changing_containers.entry_lock(instance.name):
             # See if the container was already started


### PR DESCRIPTION
Firstly, this allows profiles to inherit from each other, so that we can define a few base profiles and have team-specific profiles inherit from those and keep up to date with changes. This is done by using the `inherits` key in a profile, like so:

```
inherits: tiny
containers:
    core-web:
        links:
            optional:
                - mysql-structured-content
```

This will allow people to replace their old `.tug.yaml` files with a `personal-foobar.yaml` file in the profiles directory, inheriting as appropriate (and gitignored)

Secondly, it changes the links keys from `ignore_links`, `links` and `extra_links` in various different meanings to a consistent `links` dictionary with `optional` and `required` sub-keys. The old versions still work for now for compatability.