### PR TITLE
Don't error when "links" is missing from profile details

### DIFF
--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -113,12 +113,13 @@ class Profile:
                 warnings.warn("Cannot apply profile for nonexistent container {}".format(name))
                 continue
             # Apply container links
-            if details["links"]["required"] or details["links"]["optional"]:
-                self.graph.set_dependencies(
-                    container,
-                    [self.graph[link]
-                    for link in self.calculate_links(container)],
-                )
+            if "links" in details:
+                if details["links"]["required"] or details["links"]["optional"]:
+                    self.graph.set_dependencies(
+                        container,
+                        [self.graph[link]
+                        for link in self.calculate_links(container)],
+                    )
             # Set flag saying it's specified in a profile (for bay build
             # profile) - not set for the user profile for now
             # TODO: remove user profile restriction with default boot compat stuff


### PR DESCRIPTION
This fixes the error that was occuring after containers were injected into a profile during `bay mount`.