### PR TITLE
Only decode profile name if one is set

### DIFF
--- a/bay/containers/profile.py
+++ b/bay/containers/profile.py
@@ -26,7 +26,10 @@ class Profile:
     def __attrs_post_init__(self):
         if self.load_immediately:
             self.load()
-        self.name = os.path.basename(self.file_path).split(".")[0]
+        if self.file_path:
+            self.name = os.path.basename(self.file_path).split(".")[0]
+        else:
+            self.name = "<empty>"
 
     def load(self):
         """


### PR DESCRIPTION
This fixes the problem where a fresh installation tries to get the name from a path of `None`