### PR TITLE
Docker-for-Mac caching

### DIFF
--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -193,7 +193,7 @@ class Host(object):
         """
         if self.is_docker_for_mac:
             version_info = self.client.version()
-            base_version = version_info['Version'].split("-")
+            base_version = version_info['Version'].split("-")[0]
             return LooseVersion(base_version) >= LooseVersion("17.05.0")
         else:
             return False

--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -197,4 +197,3 @@ class Host(object):
             return LooseVersion(base_version) >= LooseVersion("17.05.0")
         else:
             return False
-

--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -3,6 +3,7 @@ import docker
 import os
 import sys
 import urllib.parse
+from distutils.version import LooseVersion
 
 from ..exceptions import DockerNotAvailableError
 from ..utils.functional import cached_property, thread_cached_property
@@ -190,4 +191,10 @@ class Host(object):
         If the host supports passing the "cached" flag to volumes to speed them
         up (implemented in Docker for Mac)
         """
-        return self.is_docker_for_mac
+        if self.is_docker_for_mac:
+            version_info = self.client.version()
+            base_version = version_info['Version'].split("-")
+            return LooseVersion(base_version) >= LooseVersion("17.05.0")
+        else:
+            return False
+

--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -1,6 +1,7 @@
 import attr
 import docker
 import os
+import sys
 import urllib.parse
 
 from ..exceptions import DockerNotAvailableError
@@ -170,3 +171,23 @@ class Host(object):
         build, which is the gateway of the default bridge network.
         """
         return self.client.inspect_network("bridge")['IPAM']['Config'][0]['Gateway']
+
+    @cached_property
+    def is_docker_for_mac(self):
+        """
+        Works out if the current install is docker for mac or docker-machine
+        based.
+        """
+        if sys.platform != "darwin":
+            return False
+        if self.url_scheme != "unix":
+            return False
+        return True
+
+    @cached_property
+    def supports_cached_volumes(self):
+        """
+        If the host supports passing the "cached" flag to volumes to speed them
+        up (implemented in Docker for Mac)
+        """
+        return self.is_docker_for_mac

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -236,6 +236,7 @@ class FormationRunner:
             })
 
             # Work out volumes configuration
+            volume_mode = "rw,cached" if self.host.supports_cached_volumes else "rw"
             volume_mountpoints = []
             volume_binds = {}
             for mount_path, source in instance.container.bound_volumes.items():
@@ -244,10 +245,10 @@ class FormationRunner:
                         "Volume mount source directory {} does not exist".format(source)
                     )
                 volume_mountpoints.append(mount_path)
-                volume_binds[source] = {"bind": mount_path, "mode": "rw"}
+                volume_binds[source] = {"bind": mount_path, "mode": volume_mode}
             for mount_path, source in instance.container.named_volumes.items():
                 volume_mountpoints.append(mount_path)
-                volume_binds[source] = {"bind": mount_path, "mode": "rw"}
+                volume_binds[source] = {"bind": mount_path, "mode": volume_mode}
 
             # Add any active devmodes
             for mount_name in instance.devmodes:
@@ -255,7 +256,7 @@ class FormationRunner:
                     volume_mountpoints.append(mount_path)
                     source = os.path.abspath(source)
                     if os.path.exists(source):
-                        volume_binds[source] = {"bind": mount_path, "mode": "rw"}
+                        volume_binds[source] = {"bind": mount_path, "mode": volume_mode}
                     else:
                         raise NotFoundException("The volume source path {} does not exist".format(source))
 


### PR DESCRIPTION
This enables Docker For Mac caching on a host-by-host basis, if that host appears to be a local, Mac OS host with a unix-based socket connection.