### PR TITLE
Ensure Container has __hash__ with attrs 17.1

### DIFF
--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -7,7 +7,7 @@ import attr
 from ..exceptions import BadConfigError
 
 
-@attr.s
+@attr.s(hash=True)
 class Container:
     """
     Represents a single container type that's available to run (not a running container -


### PR DESCRIPTION
The most recent release of attrs removed `__hash__` as existing by default in a rare breaking change.