### PR TITLE
Upgrade bay to docker python binding 2.3

### DIFF
--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -129,7 +129,7 @@ class Host(object):
             )
         # Make client
         try:
-            return docker.Client(
+            return docker.APIClient(
                 base_url=self.url,
                 version="auto",
                 timeout=10,

--- a/bay/plugins/volume.py
+++ b/bay/plugins/volume.py
@@ -72,7 +72,7 @@ def destroy(app, host, name):
     GarbageCollector(host).gc_all(task)
     # Remove the volume
     try:
-        host.client.remove_volume(name)
+        host.client.remove_volume(name, force=True)
     except NotFound:
         task.add_extra_info("There is no volume called {}".format(name))
         task.finish(status="Not found", status_flavor=Task.FLAVOR_BAD)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'attrs',
         'Click>=6.6',
         'PyYAML',
-        'docker-py>=1.6',
+        'docker~=2.3',
         'dockerpty==0.4.1',
         'scandir',
         'requests<2.11.0',


### PR DESCRIPTION
This is quite a jump, but these were the only changes that affected us I could pull out of the changlog (I refrained from using the new prune methods for garbage collection as we need to support API 1.24)