### PR TITLE
Print top-level tasks with their main line at the bottom

### DIFF
--- a/bay/cli/tasks.py
+++ b/bay/cli/tasks.py
@@ -154,12 +154,14 @@ class Task:
             status_string = YELLOW(status_string)
         # Print out our line
         indent_string = " " * (self.INDENT_AMOUNT * indent)
-        yield "{}{}: {}{}".format(
+        main_line = "{}{}: {}{}".format(
             indent_string,
             CYAN(self.name),
             progress_string,
             status_string,
         )
+        if indent > 0:
+            yield main_line
         if not (self.finished and self.collapse_if_finished):
             # Print out extra info
             indent_string = (indent + 1) * (" " * self.INDENT_AMOUNT)
@@ -168,6 +170,8 @@ class Task:
             # Print out subtasks
             for subtask in self.subtasks:
                 yield from subtask.output(terminal_width, indent=indent + 1)
+        if indent == 0:
+            yield main_line
 
     def clear_and_output(self):
         """

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -155,7 +155,8 @@ def build(app, containers, host, cache, recursive, verbose):
                 click.echo("  " + remove_ansi(line).rstrip())
             click.echo("See full build log at {log}".format(log=click.format_filename(logfile_name)), err=True)
             sys.exit(1)
-    click.echo()
+
+    task.finish(status="Done", status_flavor=Task.FLAVOR_GOOD)
 
     # Show total build time metric after everything is complete
     end_time = datetime.datetime.now().replace(microsecond=0)


### PR DESCRIPTION
This makes it more obvious when it completes. Also fixes build to say
it's completed.