### PR TITLE
Remove force=True when destroying a volume

### DIFF
--- a/bay/plugins/volume.py
+++ b/bay/plugins/volume.py
@@ -72,7 +72,7 @@ def destroy(app, host, name):
     GarbageCollector(host).gc_all(task)
     # Remove the volume
     try:
-        host.client.remove_volume(name, force=True)
+        host.client.remove_volume(name)
     except NotFound:
         task.add_extra_info("There is no volume called {}".format(name))
         task.finish(status="Not found", status_flavor=Task.FLAVOR_BAD)


### PR DESCRIPTION
When using incompatible API Version, fixes the error of:
`docker.errors.InvalidVersion: force removal was introduced in API 1.25`