### PR TITLE
Change registry interface to have separate login, add push command

### DIFF
--- a/bay/exceptions.py
+++ b/bay/exceptions.py
@@ -47,6 +47,13 @@ class DockerRuntimeError(Exception):
         self.instance = instance
 
 
+class RegistryRequiresLogin(Exception):
+    """
+    Raised by a registry handler when a registry has not been logged in to
+    and so cannot be used.
+    """
+
+
 class ImageNotFoundException(Exception):
     """
     Raised when the image requested does not exist on the docker host being

--- a/bay/plugins/registry.py
+++ b/bay/plugins/registry.py
@@ -1,0 +1,67 @@
+import attr
+import click
+
+from .base import BasePlugin
+from ..cli.argument_types import HostType, ContainerType
+from ..exceptions import RegistryRequiresLogin
+
+
+@attr.s
+class RegistryPlugin(BasePlugin):
+    """
+    Plugin for fetching and uploading images
+    """
+
+    def load(self):
+        self.add_command(registry)
+        self.add_command(push)
+
+
+@click.group()
+def registry():
+    """
+    Allows operations on registries.
+    """
+    pass
+
+
+@registry.command()
+@click.option("--host", "-h", type=HostType(), default="default")
+@click.pass_obj
+def status(app, host):
+    """
+    Gives registry status
+    """
+    registry_instance = host.images.get_registry(app)
+    if registry_instance is None:
+        click.echo("No registry is configured on this project.")
+        return
+    try:
+        url = registry_instance.url(host)
+    except RegistryRequiresLogin:
+        click.echo("Registry requires login. Run `bay registry login` to do so.")
+    else:
+        click.echo("Registry configured, docker URL: %s" % url)
+
+
+@registry.command()
+@click.option("--host", "-h", type=HostType(), default="default")
+@click.pass_obj
+def login(app, host):
+    """
+    Logs into a registry
+    """
+    registry_instance = host.images.get_registry(app)
+    registry_instance.login(host, app.root_task)
+
+
+@click.command()
+@click.option("--host", "-h", type=HostType(), default="default")
+@click.argument("container", type=ContainerType())
+@click.argument("tag")
+@click.pass_obj
+def push(app, host, container, tag):
+    """
+    Pushes an image up to a registry
+    """
+    host.images.push_image_version(app, container.image_name, tag, app.root_task)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         mounts = bay.plugins.mounts:DevModesPlugin
         profile = bay.plugins.profile:ProfilesPlugin
         ps = bay.plugins.ps:PsPlugin
+        registry = bay.plugins.registry:RegistryPlugin
         run = bay.plugins.run:RunPlugin
         ssh_agent = bay.plugins.ssh_agent:SSHAgentPlugin
         tail = bay.plugins.tail:TailPlugin


### PR DESCRIPTION
This changes the registry interface significantly as we move to having the login phase as a separate command (`bay registry login`). It also makes the registry plugin its own class with methods rather than a callable.

It also adds a `bay push` command and the related code in the `images` module to support it.