### PR TITLE
Pre-build volume providers when building containers

### DIFF
--- a/bay/constants.py
+++ b/bay/constants.py
@@ -3,6 +3,7 @@ class PluginHook:
     POST_BUILD = "post-build"
     PRE_START = "pre-start"
     POST_START = "post-start"
+    PRE_GROUP_BUILD = "pre-group-build"
     DOCKER_FAILURE = "docker-fail"
 
     valid_hooks = frozenset([
@@ -10,5 +11,6 @@ class PluginHook:
         POST_BUILD,
         PRE_START,
         POST_START,
+        PRE_GROUP_BUILD,
         DOCKER_FAILURE,
     ])

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -10,6 +10,7 @@ from ..cli.tasks import Task
 from ..docker.build import Builder
 from ..exceptions import BuildFailureError, ImagePullFailure
 from ..utils.sorting import dependency_sort
+from ..constants import PluginHook
 
 
 @attr.s
@@ -131,6 +132,8 @@ def build(app, containers, host, cache, recursive, verbose):
             order=CYAN(", ".join([container.name for container in ancestors_to_build])),
         ),
     )
+
+    app.run_hooks(PluginHook.PRE_GROUP_BUILD, host=host, containers=ancestors_to_build, task=task)
 
     for container in ancestors_to_build:
         image_builder = Builder(

--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -95,16 +95,16 @@ class BuildVolumesPlugin(BasePlugin):
         to recreate the volume if the image's ID (hash) has changed.
         """
         image_details = host.client.inspect_image(container.image_name)
+        provides_volume = container.extra_data.get("provides-volume", None)
 
-        def should_extract_volume(volume_name):
+        def should_extract_volume():
             try:
-                volume_details = host.client.inspect_volume(volume_name)
+                volume_details = host.client.inspect_volume(provides_volume)
             except NotFound:
                 return True
             return volume_details.get('Labels', {}).get('build_id') != image_details['Id']
 
-        provides_volume = container.extra_data.get("provides-volume", None)
-        if provides_volume and should_extract_volume(provides_volume):
+        if provides_volume and should_extract_volume():
             # Stop all containers that have the volume mounted
             formation = FormationIntrospector(host, self.app.containers).introspect()
             instances_to_remove = []

--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -134,7 +134,7 @@ class BuildVolumesPlugin(BasePlugin):
                 volume_task.update(status="Removed {}. Recreating".format(provides_volume))
             except NotFound:
                 volume_task.update(status="Volume {} not found. Creating")
-            volume = host.client.create_volume(provides_volume, labels={'build_id': image_details['Id']})
+            host.client.create_volume(provides_volume, labels={'build_id': image_details['Id']})
 
             # Configure the container
             volume_mountpoints = ["/volume/"]

--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -98,13 +98,15 @@ class BuildVolumesPlugin(BasePlugin):
         provides_volume = container.extra_data.get("provides-volume", None)
 
         def should_extract_volume():
+            if not provides_volume:
+                return False
             try:
                 volume_details = host.client.inspect_volume(provides_volume)
             except NotFound:
                 return True
             return volume_details.get('Labels', {}).get('build_id') != image_details['Id']
 
-        if provides_volume and should_extract_volume():
+        if should_extract_volume():
             # Stop all containers that have the volume mounted
             formation = FormationIntrospector(host, self.app.containers).introspect()
             instances_to_remove = []


### PR DESCRIPTION
The goal is to automatically build and extract volumes when building containers that require them. In order to avoid extracting volumes that have not changed, we also want to prevent extracting a volume if the hash of its providing container has not changed. 

Adds a new hook called `PRE_GROUP_BUILD` that triggers before building a container and its ancestors. The only consumer of this hook is `BuildVolumesPlugin.pre_group_build`, which builds any provided volumes that are required by the containers about to be built.

Also updated `BuildVolumesPlugin.post_build` to only extract volumes that need to be extracted. It now caches the ID of the volume provider in the volume labels when creating the volume. After building a volume provider, it checks to see if the new ID differs from the cached ID before extracting the volume.

Volume labels cannot be changed without destroying and recreating the volume, so `post_build` now removes the volume and recreates it with the new label. In order to do this, it must stop and remove any containers that have the volume mounted.