### PR TITLE
Increasing DockerAPI timeout to 42s, catching ReadTimeout exception

### DIFF
--- a/bay/cli/__init__.py
+++ b/bay/cli/__init__.py
@@ -5,9 +5,10 @@ import sys
 import os
 import traceback
 import attr
+import requests
 
 from .alias_group import SpellcheckableAliasableGroup
-from .colors import PURPLE, RED
+from .colors import PURPLE, RED, YELLOW
 from .tasks import RootTask
 from ..config import Config
 from ..constants import PluginHook
@@ -200,6 +201,9 @@ class AppGroup(SpellcheckableAliasableGroup):
             # Run the failure hooks, printing a default error if nothing is hooked in
             if not self.app.run_hooks(PluginHook.DOCKER_FAILURE):
                 click.echo(RED(str(e)))
+            sys.exit(1)
+        except requests.exceptions.ReadTimeout as e:
+            click.echo(YELLOW("Transient Docker connection error, please try again."))
             sys.exit(1)
 
 

--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -132,7 +132,7 @@ class Host(object):
             return docker.APIClient(
                 base_url=self.url,
                 version="auto",
-                timeout=10,
+                timeout=42,
                 tls=tls,
             )
         except docker.errors.DockerException:


### PR DESCRIPTION
Fix for tracebacks like 
```Traceback (most recent call last):
  File "/Users/_____/.virtualenvs/bay/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py", line 385, in _make_request
    httplib_response = conn.getresponse(buffering=True)
TypeError: getresponse() got an unexpected keyword argument 'buffering'

During handling of the above exception, another exception occurred:
[...]
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='192.168.90.100', port=2376): Read timed out. (read timeout=10)```