### PR TITLE
Make `volume destroy` fail with a nice error message if instances are using the volume

### DIFF
--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -62,6 +62,12 @@ class ContainerFormation:
         del self.container_instances[instance.name]
         instance.formation = None
 
+    def remove_instances(self, instances):
+        for instance in instances:
+            # Make sure that it was not removed from the formation already as a dependent
+            if instance.formation:
+                self.remove_instance(instance)
+
     def add_container(self, container, host):
         """
         Adds a container to run inside the formation along with all dependencies.
@@ -131,6 +137,12 @@ class ContainerFormation:
                 return instance
 
         raise ValueError("Could not find a running instance of {}".format(container_name))
+
+    def get_instances_using_volume(self, name):
+        """
+        Return a list of instances that require the named volume.
+        """
+        return [instance for instance in self if name in instance.container.named_volumes.values()]
 
     def __getitem__(self, key):
         return self.container_instances[key]

--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -110,14 +110,9 @@ class BuildVolumesPlugin(BasePlugin):
             # Stop all containers that have the volume mounted
             formation = FormationIntrospector(host, self.app.containers).introspect()
             # Keep track of instances to remove after they are stopped
-            instances_to_remove = []
-            for instance in list(formation):
-                if provides_volume in instance.container.named_volumes.values():
-                    instances_to_remove.append(instance)
-                    # Make sure that it was not removed from the formation already as a dependent
-                    if instance.formation:
-                        formation.remove_instance(instance)
+            instances_to_remove = formation.get_instances_using_volume(provides_volume)
             if instances_to_remove:
+                formation.remove_instances(instances_to_remove)
                 stop_task = Task("Stopping containers", parent=task)
                 FormationRunner(self.app, host, formation, stop_task).run()
                 stop_task.finish(status="Done", status_flavor=Task.FLAVOR_GOOD)

--- a/bay/plugins/volume.py
+++ b/bay/plugins/volume.py
@@ -2,7 +2,6 @@ import attr
 import click
 from docker.errors import NotFound, APIError
 from io import BytesIO
-import re
 import tarfile
 
 from .base import BasePlugin


### PR DESCRIPTION
Makes the `volume destroy` command check the current configuration for instances that are using the named volume. If any instances are found, it fails with a helpful error message including a list of the conflicting instances.

Also updated the volume build plugin to use the new methods on `ContainerFormation` to find and remove instances that are using the volume.