### PR TITLE
HTTPS wait optionally checks CA certs, and fails helpfully

### DIFF
--- a/bay/docker/images.py
+++ b/bay/docker/images.py
@@ -104,7 +104,7 @@ class ImageRepository:
         task = Task(
             "Pulling remote image {}:{}".format(image_name, image_tag),
             parent=parent_task,
-            progress_formatter=lambda x: "{} MB".format(x // (1024**2)),
+            progress_formatter=lambda x: "{} MB".format(x // (1024 ** 2)),
         )
 
         remote_name = "{registry_url}/{image_name}".format(
@@ -209,7 +209,7 @@ class ImageRepository:
         task = Task(
             "Pushing image {}:{}".format(image_name, image_tag),
             parent=parent_task,
-            progress_formatter=lambda x: "{} MB".format(x // (1024**2)),
+            progress_formatter=lambda x: "{} MB".format(x // (1024 ** 2)),
         )
 
         # Work out the name it needs to be and tag the image as that

--- a/bay/plugins/volume.py
+++ b/bay/plugins/volume.py
@@ -114,7 +114,7 @@ def copy_to_docker(app, host, src, container_name, volume_name):
         host.client.put_archive(container=instance.name,
                                 path=path,
                                 data=tar_stream)
-    except APIError as e:
+    except APIError:
         task.finish(status="Failed to copy", status_flavor=Task.FLAVOR_BAD)
 
     else:


### PR DESCRIPTION
HTTPS waits have the option not to check CA certs, and default to not checking them. If `verify_cert` is `True`, then it will check the cert against the certs loaded by the SSL library, but will not check the hostname (because the hostname is probably never going to be correct anyway).

Changes the behavior of the wait plugin slightly, so that any exception that bubbles up from a wait instance causes the plugin to fail with a pretty error, rather than printing the whole traceback.