### PR TITLE
Account for the fact that "Labels" can be None

### DIFF
--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -104,7 +104,8 @@ class BuildVolumesPlugin(BasePlugin):
                 volume_details = host.client.inspect_volume(provides_volume)
             except NotFound:
                 return True
-            return volume_details.get("Labels", {}).get("build_id") != image_details["Id"]
+            labels = volume_details.get("Labels") or {}
+            return labels.get("build_id") != image_details["Id"]
 
         if should_extract_volume():
             # Stop all containers that have the volume mounted


### PR DESCRIPTION
There is a bug where volumes created using an old version of bay have `"Labels"` set to `None`, causing an error. This is the fix.