### PR TITLE
Prune containers before trying to remove volumes

### DIFF
--- a/bay/plugins/build_volumes.py
+++ b/bay/plugins/build_volumes.py
@@ -2,6 +2,7 @@ import attr
 from docker.errors import NotFound
 
 from .base import BasePlugin
+from .gc import GarbageCollector
 from ..cli.tasks import Task
 from ..constants import PluginHook
 from ..docker.build import Builder
@@ -122,6 +123,9 @@ class BuildVolumesPlugin(BasePlugin):
                     host.client.remove_container(instance.name)
                     remove_task.update(status="Removed {}".format(instance.name))
                 remove_task.finish(status="Done", status_flavor=Task.FLAVOR_GOOD)
+
+            # Prune any orphan stopped containers, so we don't get conflict errors
+            GarbageCollector(host).gc_containers(task)
 
             volume_task = Task("(Re)creating volume {}".format(provides_volume), parent=task)
             # Recreate the volume with the new image ID


### PR DESCRIPTION
The `BuildVolumesPlugin.post_build` method removes any volumes that are out of date and need to be recreated. However, it needs to make sure that there are no stopped containers that have the volume mounted, otherwise Docker will throw an exception. This simply adds a gc step to `post_build` before (re)creating the volume.