### PR TITLE
Automatically rebuild system containers along with profile, and restart them when they change

### DIFF
--- a/bay/constants.py
+++ b/bay/constants.py
@@ -4,6 +4,7 @@ class PluginHook:
     PRE_START = "pre-start"
     POST_START = "post-start"
     PRE_GROUP_BUILD = "pre-group-build"
+    POST_GROUP_BUILD = "post-group-build"
     DOCKER_FAILURE = "docker-fail"
 
     valid_hooks = frozenset([
@@ -12,5 +13,6 @@ class PluginHook:
         PRE_START,
         POST_START,
         PRE_GROUP_BUILD,
+        POST_GROUP_BUILD,
         DOCKER_FAILURE,
     ])

--- a/bay/docker/build.py
+++ b/bay/docker/build.py
@@ -11,6 +11,7 @@ from docker.utils import exclude_paths
 
 from ..cli.colors import CYAN, remove_ansi
 from ..cli.tasks import Task
+from ..constants import PluginHook
 
 from ..exceptions import BuildFailureError, FailedCommandException
 
@@ -80,7 +81,7 @@ class Builder:
         progress = 0
         start_time = datetime.datetime.now().replace(microsecond=0)
 
-        self.app.run_hooks('pre-build', host=self.host, container=self.container, task=self.task)
+        self.app.run_hooks(PluginHook.PRE_BUILD, host=self.host, container=self.container, task=self.task)
 
         try:
             # Prep normalised context
@@ -132,7 +133,7 @@ class Builder:
 
         else:
             # Run post-build hooks
-            self.app.run_hooks('post-build', host=self.host, container=self.container, task=self.task)
+            self.app.run_hooks(PluginHook.POST_BUILD, host=self.host, container=self.container, task=self.task)
 
             # Print out end-of-build message
             end_time = datetime.datetime.now().replace(microsecond=0)

--- a/bay/plugins/base.py
+++ b/bay/plugins/base.py
@@ -38,7 +38,7 @@ class BasePlugin(object, metaclass=PluginMetaclass):
     app = attr.ib()
 
     # Simple plugin dependency checking - any strings in requires must be
-    # in exactly one other loaded plugin in provides.
+    # in exactly one other loaded plugin's provides.
     provides = []
     requires = []
 

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -53,7 +53,8 @@ def build(app, containers, host, cache, recursive, verbose):
     for container in containers:
         if container is ContainerType.Profile:
             for con in app.containers:
-                if app.containers.options(con).get('in_profile'):
+                # When building the profile, rebuild system containers too
+                if app.containers.options(con).get('in_profile') or con.system:
                     containers_to_pull.append(con)
         else:
             containers_to_build.append(container)
@@ -158,6 +159,8 @@ def build(app, containers, host, cache, recursive, verbose):
                 click.echo("  " + remove_ansi(line).rstrip())
             click.echo("See full build log at {log}".format(log=click.format_filename(logfile_name)), err=True)
             sys.exit(1)
+
+    app.run_hooks(PluginHook.POST_GROUP_BUILD, host=host, containers=ancestors_to_build, task=task)
 
     task.finish(status="Done", status_flavor=Task.FLAVOR_GOOD)
 

--- a/bay/plugins/system.py
+++ b/bay/plugins/system.py
@@ -1,0 +1,24 @@
+from .base import BasePlugin
+from ..constants import PluginHook
+from ..docker.introspect import FormationIntrospector
+
+
+class SystemContainerBuildPlugin(BasePlugin):
+
+    def load(self):
+        self.system_contaienr_cache = {}
+        self.add_hook(PluginHook.POST_GROUP_BUILD, self.post_group_build)
+
+    def post_group_build(self, host, containers, task):
+        """Restart all running system containers whose IDs have changed."""
+        formation = FormationIntrospector(host, self.app.containers).introspect()
+        containers_to_restart = set()
+        for container in containers:
+            if container.system:
+                # If the running instance is based on an outdated image, restart it
+                instance = formation.get_container_instance(container.name)
+                image_details = host.client.inspect_image(container.image_name)
+                if instance and image_details and image_details["Id"] != instance.image_id:
+                    containers_to_restart.add(container)
+        if containers_to_restart:
+            self.app.invoke("restart", containers=containers_to_restart)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         registry = bay.plugins.registry:RegistryPlugin
         run = bay.plugins.run:RunPlugin
         ssh_agent = bay.plugins.ssh_agent:SSHAgentPlugin
+        system = bay.plugins.system:SystemContainerBuildPlugin
         tail = bay.plugins.tail:TailPlugin
         volume = bay.plugins.volume:VolumePlugin
         waits = bay.plugins.waits:WaitsPlugin


### PR DESCRIPTION
Updated the `build` command to include system containers in `build profile`. Added a new plugin hook, `POST_GROUP_BUILD`, and a new plugin `SystemContainerBuildPlugin` that restarts outdated system containers after the build finishes.