### PR TITLE
Fix ValueError when a system container is not running

### DIFF
--- a/bay/plugins/system.py
+++ b/bay/plugins/system.py
@@ -16,7 +16,10 @@ class SystemContainerBuildPlugin(BasePlugin):
         for container in containers:
             if container.system:
                 # If the running instance is based on an outdated image, restart it
-                instance = formation.get_container_instance(container.name)
+                try:
+                    instance = formation.get_container_instance(container.name)
+                except ValueError:
+                    continue
                 image_details = host.client.inspect_image(container.image_name)
                 if instance and image_details and image_details["Id"] != instance.image_id:
                     containers_to_restart.add(container)


### PR DESCRIPTION
I didn't realize that `get_container_instance` can raise a `ValueError`. Just catch and continue.