### PR TITLE
Add memory limit option to container and profile configuration

### DIFF
--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -190,10 +190,11 @@ class Container:
         # Build args to pass into the container; right now, these are only settable by plugins.
         self.buildargs = {}
         # Store all extra data so plugins can get to it
+        self.mem_limit = config_data.get("mem_limit", 0)
         self.extra_data = {
             key: value
             for key, value in config_data.items()
-            if key not in ["ports", "build_checks", "devmodes", "foreground", "links", "waits", "volumes", "image_tag"]
+            if key not in ["ports", "build_checks", "devmodes", "foreground", "links", "waits", "volumes", "image_tag", "mem_limit"]
         }
 
     def get_parent_value(self, name, default):

--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -194,7 +194,17 @@ class Container:
         self.extra_data = {
             key: value
             for key, value in config_data.items()
-            if key not in ["ports", "build_checks", "devmodes", "foreground", "links", "waits", "volumes", "image_tag", "mem_limit"]
+            if key not in {
+                "ports",
+                "build_checks",
+                "devmodes",
+                "foreground",
+                "links",
+                "waits",
+                "volumes",
+                "image_tag",
+                "mem_limit",
+            }
         }
 
     def get_parent_value(self, name, default):

--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -216,6 +216,7 @@ class ContainerInstance:
             devmodes=self.devmodes,
             ports=self.ports,
             environment=self.environment,
+            mem_limit=self.mem_limit,
             command=self.command,
             foreground=self.foreground,
         )
@@ -233,6 +234,7 @@ class ContainerInstance:
             self.devmodes != other.devmodes or
             self.ports != other.ports or
             self.environment != other.environment or
+            self.mem_limit != other.mem_limit or
             self.command != other.command or
             other.foreground or
             self.foreground

--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -106,6 +106,7 @@ class ContainerFormation:
             devmodes=devmodes,
             foreground=container.foreground,
             environment=container.environment,
+            mem_limit=container.mem_limit,
         )
         self.add_instance(instance)
         return instance
@@ -178,6 +179,7 @@ class ContainerInstance:
     devmodes = attr.ib(default=attr.Factory(set), repr=False, cmp=False)
     ports = attr.ib(default=attr.Factory(dict), repr=False, cmp=False)
     environment = attr.ib(default=attr.Factory(dict), repr=False, cmp=False)
+    mem_limit = attr.ib(default=0, repr=False, cmp=False)
     command = attr.ib(default=None, repr=False, cmp=False)
     foreground = attr.ib(default=None, repr=False, cmp=False)
     formation = attr.ib(default=None, init=False, repr=False, cmp=False)

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -273,6 +273,7 @@ class FormationRunner:
                 volumes=volume_mountpoints,
                 name=instance.name,
                 host_config=self.host.client.create_host_config(
+                    mem_limit=instance.mem_limit,
                     binds=volume_binds,
                     port_bindings=instance.ports,
                     publish_all_ports=True,


### PR DESCRIPTION
Add the option to specify a memory limit for containers using the `"mem_limit"` key in the container or profile YAML file.

The limit may be specified as either a number of bytes (float or int) or as a string in the format described in the [Docker docs](https://docs.docker.com/engine/admin/resource_constraints/#limit-a-containers-access-to-memory). Fortunately, if you specify an invalid value, Docker will raise a helpful exception explaining the format.

While I was in `profile.py`, I changed a bunch of single quotes to double quotes as well.