### PR TITLE
Add an argument to bay tail specifying the number of lines to print

### DIFF
--- a/bay/plugins/tail.py
+++ b/bay/plugins/tail.py
@@ -21,10 +21,11 @@ class TailPlugin(BasePlugin):
 @click.option("--host", "-h", type=HostType(), default="default")
 @click.option('--follow/--no-follow', '-f', default=False)
 @click.argument("container", type=ContainerType())
+@click.argument("lines", default="10")
 @click.pass_obj
-def tail(app, host, container, follow=False):
+def tail(app, host, container, lines, follow=False):
     """
-    Shows logs from a container
+    Shows logs from a container. Optional second argument specifies a number of lines to print, or "all".
     """
     # We don't use formation here as it doesn't include stopped containers;
     # instead, we manually go through the list.
@@ -37,8 +38,14 @@ def tail(app, host, container, follow=False):
         click.echo(RED("Cannot find instance of {} to print logs for.".format(container.name)))
         sys.exit(1)
     # Either stream or just print directly
+    if lines != "all":
+        try:
+            lines = int(lines)
+        except:
+            click.echo(RED("Invalid number of lines: {}".format(lines)))
+            sys.exit(1)
     if follow:
-        for line in host.client.logs(container_name, stream=True):
+        for line in host.client.logs(container_name, tail=lines, stream=True):
             click.echo(line, nl=False)
     else:
-        click.echo(host.client.logs(container_name))
+        click.echo(host.client.logs(container_name, tail=lines))


### PR DESCRIPTION
Add an option to limit the number of lines printed. If using `-f`, this limits the number of lines initially printed, but the output will still follow the log as normal. If the option is omitted, it prints the whole log as before.

`bay tail core-web` --> prints the whole `core-web` log, as before
`bay tail core-web 20` --> prints the last 20 lines of the `core-web` log
`bay tail core-web 20 -f` --> prints the last 20 lines of the `core-web` log, and continues printing any lines that are added subsequently