### PR TITLE
Fix exception when trying to introspect a running container with no configuration

### DIFF
--- a/bay/containers/graph.py
+++ b/bay/containers/graph.py
@@ -81,15 +81,18 @@ class ContainerGraph:
         # Link by dependency
         for container in containers:
             # Runtime dependencies
-            self.set_dependencies(
-                container,
-                [
-                    self.containers[link_name]
-                    for link_name, link_details
-                    in container.links.items()
-                    if link_details.get("required")
-                ],
-            )
+            try:
+                self.set_dependencies(
+                    container,
+                    [
+                        self.containers[link_name]
+                        for link_name, link_details
+                        in container.links.items()
+                        if link_details.get("required")
+                    ],
+                )
+            except KeyError as e:
+                raise BadConfigError("Container not found for required link {}".format(e.args[0]))
             # Build dependencies
             if container.build_parent_in_prefix:
                 self.add_build_dependency(container, self.containers[container.build_parent.split("/")[1]])


### PR DESCRIPTION
Previously, when a running Bay container had its configuration removed or renamed, subsequent invocations of Bay would throw an exception when trying to introspect the unknown container. Consequently, every command would fail with an exception and nothing could be done until the user stopped the container manually.

Updated the introspector so that `add_container` only raises a warning in this case. Leaves `introspect_single_container`'s behavior unchanged, since this is only called when starting containers and should throw an exception if a configuration is missing.

As a bonus, I added a more helpful exception when Bay tries to link a container for which it has no configuration.