### PR TITLE
Add configuration options for volumes

### DIFF
--- a/bay/containers/formation.py
+++ b/bay/containers/formation.py
@@ -143,7 +143,10 @@ class ContainerFormation:
         """
         Return a list of instances that require the named volume.
         """
-        return [instance for instance in self if name in instance.container.named_volumes.values()]
+        return [
+            instance for instance in self if
+            any(name == v.source for v in instance.container.named_volumes.values())
+        ]
 
     def __getitem__(self, key):
         return self.container_instances[key]

--- a/bay/containers/volumes.py
+++ b/bay/containers/volumes.py
@@ -1,0 +1,23 @@
+import attr
+
+
+@attr.s
+class NamedVolume:
+
+    source = attr.ib()
+    mode = attr.ib(default="rw")
+
+
+@attr.s
+class BoundVolume:
+
+    source = attr.ib()
+    mode = attr.ib(default="rw")
+    required = attr.ib(convert=bool, default=True)
+
+
+@attr.s
+class DevMode:
+
+    source = attr.ib()
+    mode = attr.ib(default="rw")

--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -69,7 +69,8 @@ class BuildPlugin(BasePlugin):
         # First, collect what volumes are provided by what containers
         providers = _get_providers(self.app)
         # Now see if any of the volumes we're trying to add need it
-        for _, name in instance.container.named_volumes.items():
+        for _, volume in instance.container.named_volumes.items():
+            name = volume.source
             if name in providers:
                 # Alright, this is one that could be provided. Does it already exist?
                 try:
@@ -194,8 +195,8 @@ def build(app, containers, host, cache, recursive, verbose):
         else:
             containers_to_build.append(container)
             for volume in container.named_volumes.values():
-                if volume in providers:
-                    containers_to_build.append(providers[volume])
+                if volume.source in providers:
+                    containers_to_build.append(providers[volume.source])
 
     # Expand containers_to_pull (At this point just the default boot containers
     # from profile) to include runtime dependencies.
@@ -206,8 +207,8 @@ def build(app, containers, host, cache, recursive, verbose):
     def container_volume_dependencies(container):
         volume_deps = set()
         for volume in container.named_volumes.values():
-            if volume in providers:
-                volume_deps.add(providers[volume])
+            if volume.source in providers:
+                volume_deps.add(providers[volume.source])
         return volume_deps
 
     containers_to_pull = dependency_sort(containers_to_pull, container_volume_dependencies)

--- a/bay/plugins/container.py
+++ b/bay/plugins/container.py
@@ -56,14 +56,14 @@ def container(app, container=None):
             click.echo(CYAN("Depended on by: ") + "(nothing)")
         # Volumes
         click.echo(CYAN("Named volumes:"))
-        for mount_point, source in container.named_volumes.items():
-            click.echo("  {}: {}".format(mount_point, source))
+        for mount_point, volume in container.named_volumes.items():
+            click.echo("  {}: {}".format(mount_point, volume.source))
         click.echo(CYAN("Bind-mounted volumes:"))
-        for mount_point, source in container.bound_volumes.items():
-            click.echo("  {}: {}".format(mount_point, source))
+        for mount_point, volume in container.bound_volumes.items():
+            click.echo("  {}: {}".format(mount_point, volume.source))
         # Devmodes
         click.echo(CYAN("Mounts (devmodes):"))
         for name, mounts in container.devmodes.items():
             click.echo("  {}:".format(name))
-            for mount_point, source in mounts.items():
-                click.echo("    {}: {}".format(mount_point, source))
+            for mount_point, volume in mounts.items():
+                click.echo("    {}: {}".format(mount_point, volume.source))


### PR DESCRIPTION
In order to make volumes more adaptable for different use cases, I've added some basic configuration options. 

Now, volumes can be specified as dictionaries with settings. There are only a few valid settings, depending on the volume type:
- All volume types have a `source`, which behaves just like the string specifier. It is required.
- All volume types have a `mode`, which is a Docker volume mode (e.g. `"rw"` for read/write or `"ro"` for read-only). It defaults to `"rw"`.
- Bound volumes have a `required` option. If this is `False`, Bay will not fail when the source directory for the volume does not exist, and will run the container without the bind mount. It defaults to `True`.

Volumes can still be specified using just a string, which corresponds to the `source` option.