### PR TITLE
Fix an error where "cached" appears more than once in the volume mode

### DIFF
--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -240,7 +240,7 @@ class FormationRunner:
             volume_binds = {}
 
             def add_volume_mount(mount_path, volume):
-                if self.host.supports_cached_volumes:
+                if self.host.supports_cached_volumes and ",cached" not in volume.mode:
                     volume.mode = volume.mode + ",cached"
                 volume_mountpoints.append(mount_path)
                 volume_binds[volume.source] = {"bind": mount_path, "mode": volume.mode}


### PR DESCRIPTION
If you specified "cached" in the volume mode and the host supports cached volumes, it will be duplicated, causing an error.