### PR TITLE
add tail log to message

### DIFF
--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -312,7 +312,7 @@ class FormationRunner:
                     elif status is False:
                         message = "{}\n\n{}".format(
                             "Container {} failed to boot!".format(instance.container.name),
-                            self.host.client.logs(instance.name['Names'][0], tail=10),
+                            self.host.client.logs(instance.name, tail=10).decode('utf-8'),
                         )
                         raise DockerRuntimeError(
                             message,

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -310,8 +310,12 @@ class FormationRunner:
                     elif status is True:
                         break
                     elif status is False:
-                        raise DockerRuntimeError(
+                        message = "{}\n\n{}".format(
                             "Container {} failed to boot!".format(instance.container.name),
+                            host.client.logs(instance.name['Names'][0], tail=10),
+                        )
+                        raise DockerRuntimeError(
+                            message,
                             code="BOOT_FAIL",
                             instance=instance,
                         )

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -11,7 +11,7 @@ from .introspect import FormationIntrospector
 from .towline import Towline
 from ..cli.tasks import Task
 from ..constants import PluginHook
-from ..exceptions import DockerRuntimeError, DockerInteractiveException, NotFoundException
+from ..exceptions import ContainerBootFailure, DockerRuntimeError, DockerInteractiveException, NotFoundException
 from ..utils.sorting import dependency_sort
 from ..utils.threading import ExceptionalThread, ThreadSet
 
@@ -288,43 +288,55 @@ class FormationRunner:
                     "com.eventbrite.bay.container": instance.container.name,
                 }
             )
+            try:
+                # Foreground containers launch into a PTY at this point. We use an exception so that
+                # it happens in the main thread.
+                if instance.foreground:
+                    def handler():
+                        dockerpty.start(self.host.client, container_pointer)
+                        self.host.client.remove_container(container_pointer)
+                    start_task.finish(status="Going to shell", status_flavor=Task.FLAVOR_GOOD)
+                    raise DockerInteractiveException(handler)
 
-            # Foreground containers launch into a PTY at this point. We use an exception so that
-            # it happens in the main thread.
-            if instance.foreground:
-                def handler():
-                    dockerpty.start(self.host.client, container_pointer)
-                    self.host.client.remove_container(container_pointer)
-                start_task.finish(status="Going to shell", status_flavor=Task.FLAVOR_GOOD)
-                raise DockerInteractiveException(handler)
+                else:
+                    # Make a towline instance and wait on it
+                    self.host.client.start(container_pointer)
+                    towline = Towline(self.host, instance.name)
+                    while True:
+                        status, message = towline.status
+                        if status is None:
+                            if message is not None:
+                                start_task.update(status=message)
+                        elif status is True:
+                            break
+                        elif status is False:
+                            raise ContainerBootFailure(
+                                "Failed during towline",
+                                instance=instance,
+                            )
+                        time.sleep(0.5)
 
-            else:
-                # Make a towline instance and wait on it
-                self.host.client.start(container_pointer)
-                towline = Towline(self.host, instance.name)
-                while True:
-                    status, message = towline.status
-                    if status is None:
-                        if message is not None:
-                            start_task.update(status=message)
-                    elif status is True:
-                        break
-                    elif status is False:
-                        message = "{}\n\n{}".format(
-                            "Container {} failed to boot!".format(instance.container.name),
-                            self.host.client.logs(instance.name, tail=10).decode('utf-8'),
-                        )
-                        raise DockerRuntimeError(
-                            message,
-                            code="BOOT_FAIL",
-                            instance=instance,
-                        )
-                    time.sleep(0.5)
+                try:
+                    # Replace the instance with an introspected copy of the live one so it has networking details
+                    instance = FormationIntrospector(self.host, self.app.containers).introspect_single_container(instance.name)
+                except DockerRuntimeError:
+                    raise ContainerBootFailure(
+                        "Failed after towline",
+                        instance=instance,
+                    )
 
-            # Replace the instance with an introspected copy of the live one so it has networking details
-            instance = FormationIntrospector(self.host, self.app.containers).introspect_single_container(instance.name)
+                # Run plugins
+                self.app.run_hooks(PluginHook.POST_START, host=self.host, instance=instance, task=start_task)
 
-            # Run plugins
-            self.app.run_hooks(PluginHook.POST_START, host=self.host, instance=instance, task=start_task)
+            except ContainerBootFailure as e:
+                message = "{}\n\n{}".format(
+                    "Container {} failed to boot! ({})".format(e.instance.container.name, e.message),
+                    self.host.client.logs(e.instance.name, tail=10).decode('utf-8'),
+                )
+                raise DockerRuntimeError(
+                    message,
+                    code="BOOT_FAIL",
+                    instance=e.instance,
+                )
 
             start_task.finish(status="Done", status_flavor=Task.FLAVOR_GOOD)

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -318,7 +318,10 @@ class FormationRunner:
 
                 try:
                     # Replace the instance with an introspected copy of the live one so it has networking details
-                    instance = FormationIntrospector(self.host, self.app.containers).introspect_single_container(instance.name)
+                    instance = FormationIntrospector(
+                        self.host,
+                        self.app.containers,
+                    ).introspect_single_container(instance.name)
                 except DockerRuntimeError:
                     raise ContainerBootFailure(
                         "Failed after towline",

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -312,7 +312,7 @@ class FormationRunner:
                     elif status is False:
                         message = "{}\n\n{}".format(
                             "Container {} failed to boot!".format(instance.container.name),
-                            host.client.logs(instance.name['Names'][0], tail=10),
+                            self.host.client.logs(instance.name['Names'][0], tail=10),
                         )
                         raise DockerRuntimeError(
                             message,

--- a/bay/exceptions.py
+++ b/bay/exceptions.py
@@ -45,6 +45,13 @@ class DockerRuntimeError(Exception):
         super(DockerRuntimeError, self).__init__(message)
         self.code = code
         self.instance = instance
+        self.message = message
+
+
+class ContainerBootFailure(DockerRuntimeError):
+    """
+    Container died while trying to boot
+    """
 
 
 class RegistryRequiresLogin(Exception):

--- a/bay/plugins/waits.py
+++ b/bay/plugins/waits.py
@@ -53,8 +53,14 @@ class WaitsPlugin(BasePlugin):
             # See if the container actually died
             if not host.container_running(instance.name):
                 task.update(status="Dead", status_flavor=Task.FLAVOR_BAD)
+
+                message = '{}\n\n{}'.format(
+                    "Container {} died while waiting for boot completion".format(instance.container.name),
+                    host.client.logs(instance.name['Names'][0], tail=10).decode('utf-8'),
+                )
                 raise DockerRuntimeError(
-                    "Container {} died while waiting for boot completion".format(instance.container.name)
+                    message,
+                    instance=instance,
                 )
             # Check the waits
             for wait_instance in list(wait_instances):

--- a/bay/plugins/waits.py
+++ b/bay/plugins/waits.py
@@ -56,7 +56,7 @@ class WaitsPlugin(BasePlugin):
 
                 message = '{}\n\n{}'.format(
                     "Container {} died while waiting for boot completion".format(instance.container.name),
-                    host.client.logs(instance.name['Names'][0], tail=10).decode('utf-8'),
+                    host.client.logs(instance.name, tail=10).decode('utf-8'),
                 )
                 raise DockerRuntimeError(
                     message,

--- a/bay/plugins/waits.py
+++ b/bay/plugins/waits.py
@@ -10,6 +10,7 @@ from ..cli.tasks import Task
 from ..constants import PluginHook
 from ..exceptions import ContainerBootFailure, DockerRuntimeError
 
+
 class WaitsPlugin(BasePlugin):
     """
     Contains the basic, standard waits. Waits' .check is called repeatedly and should return True if the condition is

--- a/bay/plugins/waits.py
+++ b/bay/plugins/waits.py
@@ -8,8 +8,7 @@ from docker.errors import NotFound
 from .base import BasePlugin
 from ..cli.tasks import Task
 from ..constants import PluginHook
-from ..exceptions import DockerRuntimeError
-
+from ..exceptions import ContainerBootFailure, DockerRuntimeError
 
 class WaitsPlugin(BasePlugin):
     """
@@ -54,12 +53,8 @@ class WaitsPlugin(BasePlugin):
             if not host.container_running(instance.name):
                 task.update(status="Dead", status_flavor=Task.FLAVOR_BAD)
 
-                message = '{}\n\n{}'.format(
-                    "Container {} died while waiting for boot completion".format(instance.container.name),
-                    host.client.logs(instance.name, tail=10).decode('utf-8'),
-                )
-                raise DockerRuntimeError(
-                    message,
+                raise ContainerBootFailure(
+                    "Failed during waits",
                     instance=instance,
                 )
             # Check the waits


### PR DESCRIPTION
The issue: When a container fails on run, a nice message is printed to the terminal regarding the containers failure, but what would be REALLY nice is to see the tail of the container that failed as well. 

Solution provided here, grab the tail output from the offending container and append it to the error message to ensure it always gets written to the terminal.