### PR TITLE
Add BAY_VOLUME_HOME for filesystem separation

### DIFF
--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -220,7 +220,11 @@ class Container:
         if git_match:
             options["source"] = "../{}/{}".format(git_match.group(1), git_match.group(2).lstrip("/"))
         if "/" in options["source"]:
-            options["source"] = os.path.abspath(os.path.join(self.graph.path, options["source"]))
+            # Allow the volume mount root to be different if needed (e.g. Windows)
+            if os.environ.get("BAY_VOLUME_HOME"):
+                options["source"] = os.path.join(os.environ["BAY_VOLUME_HOME"], options["source"])
+            else:
+                options["source"] = os.path.abspath(os.path.join(self.graph.path, options["source"]))
         return options
 
     def get_parent_value(self, name, default):

--- a/bay/docker/runner.py
+++ b/bay/docker/runner.py
@@ -246,7 +246,7 @@ class FormationRunner:
                 volume_binds[volume.source] = {"bind": mount_path, "mode": volume.mode}
 
             for mount_path, volume in instance.container.bound_volumes.items():
-                if os.path.isdir(volume.source):
+                if os.path.isdir(volume.source) or os.environ.get("BAY_VOLUME_HOME"):
                     add_volume_mount(mount_path, volume)
                 elif volume.required:
                     raise NotFoundException(
@@ -255,7 +255,7 @@ class FormationRunner:
             # Add any active devmodes
             for mount_name in instance.devmodes:
                 for mount_path, volume in instance.container.devmodes[mount_name].items():
-                    if os.path.isdir(volume.source):
+                    if os.path.isdir(volume.source) or os.environ.get("BAY_VOLUME_HOME"):
                         add_volume_mount(mount_path, volume)
                     else:
                         raise NotFoundException(

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -78,3 +78,13 @@ according to the dependencies (links) specified between containers. For example,
 if container ``www`` depends on both ``postgres`` and ``redis`` to run, but those
 two do not depend on each other, Bay will start ``postgres`` and ``redis`` in
 parallel, and once they are both up, then start ``www``.
+
+
+Volume Mounting
+---------------
+
+If you are running under a system where the Docker daemon sees the filesystem
+differently to your Bay instance (e.g. it's a remote daemon, or running in a
+virtual machine like with Docker for Windows), you can set the
+``BAY_VOLUME_HOME`` environment variable to the location that ``BAY_HOME``
+would be on that remote system.


### PR DESCRIPTION
This solves the ability to mount images when the Docker daemon sees
the filesystem differently to the Bay client (e.g. when you are running
Docker For Windows from a WSL shell)