### PR TITLE
Fix list_profiles command in docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,7 +11,7 @@ Selecting a profile
 
 The first thing to do is to select a profile. To see available profiles, run::
 
-    bay list-profiles
+    bay list_profiles
 
 Then, select one::
 


### PR DESCRIPTION
```
➜  ~ bay list-profiles
Usage: bay [OPTIONS] COMMAND [ARGS]...

Error: No such command "list-profiles", are you trying to run: list_profiles?
```