### PR TITLE
Allow non-eventbrite github volumes

### DIFF
--- a/bay/containers/container.py
+++ b/bay/containers/container.py
@@ -19,7 +19,7 @@ class Container:
     even if the actual running server is remote.
     """
     parent_pattern = re.compile(r'^FROM\s+([\S/]+)', re.IGNORECASE)
-    git_volume_pattern = re.compile(r'^\{git@github.com:eventbrite/([\w\s\-]+).git\}(.*)$')
+    git_volume_pattern = re.compile(r'^\{git@github.com:[\w\d_-]*/([\w\s\-]+).git\}(.*)$')
 
     graph = attr.ib(repr=False, hash=False, cmp=False)
     path = attr.ib(repr=False, hash=True, cmp=True)


### PR DESCRIPTION
Current code allows the specification of volumes from github repositories only if those repositories are under the "eventbrite" organization name.  This change allows any github repository to be used as the basis of a volume.