### PR TITLE
Change Docker host DNS

### DIFF
--- a/bay/docker/hosts.py
+++ b/bay/docker/hosts.py
@@ -181,8 +181,11 @@ class Host(object):
         version = LooseVersion(self.client.version()['Version'].split("-")[0])
         version_17_06 = LooseVersion("17.06.0")
         version_17_12 = LooseVersion("17.12.0")
+        version_18_03 = LooseVersion("18.03.0")
 
-        if sys.platform == "darwin" and version >= version_17_06:
+        if version >= version_18_03:
+            gateway_ip = "host.docker.internal"
+        elif sys.platform == "darwin" and version >= version_17_06:
             # MacOS + recent version of Docker for Mac
             gateway_ip = "docker.for.mac.host.internal" if version >= version_17_12 else "docker.for.mac.localhost"
         elif sys.platform == "win32" and version >= version_17_06:


### PR DESCRIPTION
Summary:
The host DNS changed in Docker 18.03, and is now the same for Docker for Mac and Docker for Windows: https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18030-ce-mac59-2018-03-26
The old DNS are deprecated.

Test Plan: `bay build ssh-agent`, then `bay shell core` and `echo $SSH_AUTH_HOST` should return `host.docker.internal` if you are at least on Docker 18.03.

Reviewers: venkatesh, aravind

Differential Revision: https://phabricator.evbhome.com/D56453