### PR TITLE
EB-77208 Ask user to run bay registry login in case of docker pull not found error.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+2.16.3 (2018-06-01)
+------------------
+- Ask user to run `bay registry login` in case of docker pull not found error.
+
 2.16.2 (2018-05-25)
 ------------------
 - Remove profile warnings

--- a/bay/version.py
+++ b/bay/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 16, 2)
+__version_info__ = (2, 16, 3)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
I was trying to reproduce the issue by altering my tokens (okta, aws and docker creds) but could not get to in a state where authentication was wrong and docker api returned "Not Found".
When forcing docker credentials to be altered at run-time, I would get an error "Too many failures while pulling".
I ended up bumping an image tag to simulate a "Not Found" error.

This fix would address the issue that we have seen.
To give the ability for users to force local build, they can set an environment variable.

Scenario 1: user get's not found error, bay exits and asks user to login to registry.
```
$ bay build             
  Pulling remote image eventbrite/cassandra-core:1.0.3: 
Building: 
Cannot pull image 671197494237.dkr.ecr.us-east-1.amazonaws.com/docker-dev/eventbrite/cassandra-core:1.0.3.
To fix this, please run `bay registry login`.
To proceed without registry, export BAY_NO_REGISTRY=yes and try again
```
Scenario 2: user set the env variable, the container is marked as not found and will be built locally.
```
$ export BAY_NO_REGISTRY=yes
$ bay build        
  Pulling remote image eventbrite/cassandra-core:1.0.3: Not found
  Pulling remote image eventbrite/change-streamer:1.0.0: Done [00:01]
  Pulling remote image eventbrite/core-php:1.0.1: Done [00:02]
Building: 
...
```