### PR TITLE
EB-84956 when building a profile with the 'inherits' property, include the parent containers in the build

### DIFF
--- a/bay/plugins/build.py
+++ b/bay/plugins/build.py
@@ -224,8 +224,10 @@ def build(app, containers, host, cache, recursive, verbose):
     containers_to_pull = dependency_sort(containers_to_pull, container_volume_dependencies)
 
     if profile is not None and profile.ignore_dependencies:
+        # List the containers defined in the current profile and its ancestors
+        profile_containers = set(sum([list(p.containers.keys()) for p in app.profiles[1:]], []))
         # If dependencies are ignored, only keep the containers defined in the profile
-        containers_to_pull = [c for c in containers_to_pull if c.name in profile.containers.keys()]
+        containers_to_pull = [c for c in containers_to_pull if c.name in profile_containers]
 
     # Try pulling each container to pull, and add it to containers_to_build if
     # it fails. If it works, remember we pulled it, so we don't have to pull it


### PR DESCRIPTION
**Summary:**
Currently if a profile defined 'ignore-dependencies: true' and 'inherits: base', when doing `bay build`, it only builds the containers listed in the profile file, not the parent (in this example the 'base' profile). The workaround for the user is to switch profile, build and re-switch profile.
With this fix, the build will include the container listed in the ancestor profile as well, so the user doesn't need to switch profile when building.

**Test Plan:**
tested with the profile base-cerberus. `bay build` and `bay up`.
