### PR TITLE
EB-90124 when building docker images do not reset file time to 0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,9 @@
-2.17.4 (2018-07-09)
+2.17.5 (2018-09-04)
+------------------
+- Do not reset file time when creating the docker image for source files. 
+This change is under a feature flag `BAY_K8=true`.
+
+2.17.4 (2018-07-09
 ------------------
 - Fix: when building a profile with the 'inherits' property, include the parent containers in the build.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 2.17.5 (2018-09-04)
 ------------------
 - Do not reset file time when creating the docker image for source files. 
-This change is under a feature flag `BAY_K8=true`.
+This change is under a feature flag `BAY_BUILD_SRC_REAL_TIME=true`.
 
 2.17.4 (2018-07-09
 ------------------

--- a/bay/docker/build.py
+++ b/bay/docker/build.py
@@ -180,7 +180,11 @@ class Builder:
         for path in paths:
             disk_location = os.path.join(self.container.path, path)
             # for Kubernetes images, use original date values for source code
-            useRealTime = 'BAY_K8' in os.environ and os.environ['BAY_K8'] == 'true' and "/src/" in disk_location
+            useRealTime = (
+                'BAY_BUILD_SRC_REAL_TIME' in os.environ
+                and os.environ['BAY_BUILD_SRC_REAL_TIME'] == 'true'
+                and "/src/" in disk_location
+            )
             # Directory addition
             if os.path.isdir(disk_location):
                 info = tarfile.TarInfo(name=path)

--- a/bay/docker/build.py
+++ b/bay/docker/build.py
@@ -179,10 +179,12 @@ class Builder:
         # For each file, add it to the tar with normalisation
         for path in paths:
             disk_location = os.path.join(self.container.path, path)
+            # for Kubernetes images, use original date values for source code
+            useRealTime = 'BAY_K8' in os.environ and os.environ['BAY_K8'] == 'true' and "/src/" in disk_location
             # Directory addition
             if os.path.isdir(disk_location):
                 info = tarfile.TarInfo(name=path)
-                info.mtime = 0
+                info.mtime = (0, os.stat(disk_location).st_mtime)[useRealTime]
                 info.mode = 0o775
                 info.type = tarfile.DIRTYPE
                 info.uid = 0
@@ -194,7 +196,7 @@ class Builder:
             elif os.path.isfile(disk_location):
                 stat = os.stat(disk_location)
                 info = tarfile.TarInfo(name=path)
-                info.mtime = 0
+                info.mtime = (0, stat.st_mtime)[useRealTime]
                 info.size = stat.st_size
                 info.mode = 0o755
                 info.type = tarfile.REGTYPE

--- a/bay/version.py
+++ b/bay/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 17, 4)
+__version_info__ = (2, 17, 5)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Preventing setting the file date to zero when creating the docker image.
Use the same date as the file system file.
- for src file only
- under a feature flag
