### PR TITLE
Use list format for binds instead of dict format for multiple mountpoints

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+2.18.0 (2018-12-17)
+-------------------
+- Use list format for binds instead of dict format for multiple mountpoints
+- Fix Flake8 issues that have popped up in newer versions
+- Include all commands in commands.rst
+- EB-90124 when building docker images do not reset file time to 0
+
 2.17.5 (2018-09-04)
 ------------------
 - Do not reset file time when creating the docker image for source files. 

--- a/bay/version.py
+++ b/bay/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 17, 5)
+__version_info__ = (2, 18, 0)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Docker's `binds` argument (defined here as `volume_binds`) can be in two formats. It can be in a list of strings `'{source}:{destination}:{mode}'`, or it can be a dict whose keys are sources and whose values are a dict of `{'bind': '{destination}', 'mode': '{mode}'}`. If you specify `binds` in dict format, the Docker SDK converts it to list format before sending it to the Docker process. However, the dict format limits you to one container mountpoint per host source. Docker permits multiple container mountpoints per host source, and the only way to specify that is with the list format. Previously we used the dict format, but this change switches to the list format to support multiple mountpoints.