### PR TITLE
Permit use of shell other than default /bin/bash

### DIFF
--- a/bay/docker/images.py
+++ b/bay/docker/images.py
@@ -14,10 +14,10 @@ from ..exceptions import ImageNotFoundException, ImagePullFailure, BadConfigErro
 
 def convert_to_json_stream(stream):
     for lines in stream:
-            if isinstance(lines, bytes):
-                lines = lines.decode("ascii")
-            for line in lines.splitlines():
-                yield json.loads(line)
+        if isinstance(lines, bytes):
+            lines = lines.decode("ascii")
+        for line in lines.splitlines():
+            yield json.loads(line)
 
 
 @attr.s
@@ -179,7 +179,7 @@ class ImageRepository:
         end_time = datetime.datetime.now().replace(microsecond=0)
         time_delta_str = str(end_time - start_time)
         if time_delta_str.startswith('0:'):
-                time_delta_str = time_delta_str[2:]
+            time_delta_str = time_delta_str[2:]
         task.finish(status='Done [{}]'.format(time_delta_str), status_flavor=Task.FLAVOR_GOOD)
 
         # Tag the remote image as the right name

--- a/bay/plugins/attach.py
+++ b/bay/plugins/attach.py
@@ -23,16 +23,17 @@ class AttachPlugin(BasePlugin):
 @click.command()
 @click.argument("container", type=ContainerType())
 @click.option("--host", "-h", type=HostType(), default="default")
+@click.option("--shell", "-s", "shell_path", default="/bin/bash")
 @click.argument("command", nargs=-1, default=None)
 @click.pass_obj
-def attach(app, container, host, command):
+def attach(app, container, host, command, shell_path):
     """
     Attaches to a container
     """
     if command:
-        shell = ['/bin/bash', '-lc', ' '.join(command)]
+        shell = [shell_path, '-lc', ' '.join(command)]
     else:
-        shell = ['/bin/bash']
+        shell = [shell_path]
 
     # See if the container is running
     formation = FormationIntrospector(host, app.containers).introspect()

--- a/bay/plugins/run.py
+++ b/bay/plugins/run.py
@@ -80,9 +80,10 @@ def run(app, containers, host, tail):
 @click.command()
 @click.argument("container", type=ContainerType())
 @click.option("--host", "-h", type=HostType(), default="default")
+@click.option("--shell", "-s", "shell_path", default="/bin/bash")
 @click.argument("command", nargs=-1, default=None)
 @click.pass_obj
-def shell(app, container, host, command):
+def shell(app, container, host, command, shell_path):
     """
     Runs a single container with foreground enabled and overridden to use bash.
     """
@@ -98,9 +99,9 @@ def shell(app, container, host, command):
         sys.exit(1)
     instance.foreground = True
     if command:
-        instance.command = ['/bin/bash -lc "{}"'.format(' '.join(command))]
+        instance.command = ['{} -lc "{}"'.format(shell_path, ' '.join(command))]
     else:
-        instance.command = ["/bin/bash -l"]
+        instance.command = ["{} -l".format(shell_path)]
     # Run that change
     task = Task("Shelling into {}".format(container.name), parent=app.root_task)
     run_formation(app, host, formation, task, [container])


### PR DESCRIPTION
This adds a simple, optional `--shell` parameter to `bay shell` and `bay attach` that permits the user to override the default `/bin/bash` with something else, such as `/bin/sh`. This is especially critical for certain lightweight containers that completely lack Bash. This also fixes a few Flake8 issues that were making this build fail.