### PR TITLE
Released Bay version 2.19.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.19.0 (2019-10-08)
+-------------------
+- [MINOR] Add support for invoke release
+- [PATCH] Migrate `convert` to `converter`
+- Permit use of shell other than default /bin/bash
+- Fix RELEASE doc
+
 2.18.0 (2018-12-17)
 -------------------
 - Use list format for binds instead of dict format for multiple mountpoints

--- a/bay/version.py
+++ b/bay/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 18, 0)
-__version__ = '.'.join(map(str, __version_info__))
+__version_info__ = (2, 19, 0)
+__version__ = '-'.join(filter(None, ['.'.join(map(str, __version_info__[:3])), (__version_info__[3:] or [None])[0]]))


### PR DESCRIPTION
Changelog Details:
- [MINOR] Add support for invoke release
- [PATCH] Migrate `convert` to `converter`
- Permit use of shell other than default /bin/bash
- Fix RELEASE doc